### PR TITLE
test: fix test cases around channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .angular/
 .vscode/
 .env
+results.xml


### PR DESCRIPTION
This fixes some test cases around channels that were not actually testing anything (false positives) due to the lack of channel and "if" clauses.  It might happen that all test cases related to message history will fail from now instead of just one, that's intended. I'm not yet sure what's causing history calls to fail, but I suspect some limits on the test keyset.