### PR TITLE
feat: file uploads

### DIFF
--- a/lib/src/entities/message-draft.ts
+++ b/lib/src/entities/message-draft.ts
@@ -1,3 +1,4 @@
+import { SendFileParameters } from "pubnub"
 import { Chat } from "./chat"
 import { User } from "./user"
 import { Channel } from "./channel"
@@ -37,6 +38,7 @@ export class MessageDraft {
   /** @internal */
   private quotedMessage: Message | undefined = undefined
   readonly config: MessageDraftConfig
+  files?: FileList | File[] | SendFileParameters["file"][] = undefined
 
   /** @internal */
   constructor(chat: Chat, channel: Channel, config?: Partial<MessageDraftConfig>) {
@@ -398,6 +400,7 @@ export class MessageDraft {
       mentionedUsers: this.transformMentionedUsersToSend(),
       textLinks: this.textLinks,
       quotedMessage: this.quotedMessage,
+      files: this.files,
     })
   }
 

--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -63,6 +63,10 @@ export class Message {
     return undefined
   }
 
+  get files() {
+    return this.content.files || []
+  }
+
   /** @internal */
   constructor(chat: Chat, params: MessageFields) {
     this.chat = chat
@@ -220,7 +224,7 @@ export class Message {
     return !!this.actions?.[type]
   }
 
-  async delete(params: DeleteParameters = {}) {
+  async delete(params: DeleteParameters & { preserveFiles?: boolean } = {}) {
     const { soft } = params
     const type = MessageActionType.DELETED
     try {
@@ -242,6 +246,12 @@ export class Message {
           end: this.timetoken,
         })
         await this.deleteThread(params)
+        if (this.files.length && !params.preserveFiles) {
+          for (const file of this.files) {
+            const { id, name } = file
+            await this.chat.sdk.deleteFile({ channel: this.channelId, id, name })
+          }
+        }
 
         return true
       }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1,4 +1,9 @@
-import PubNub, { ChannelMetadataObject, ObjectCustom, PublishParameters } from "pubnub"
+import PubNub, {
+  ChannelMetadataObject,
+  ObjectCustom,
+  PublishParameters,
+  SendFileParameters,
+} from "pubnub"
 import { User } from "./entities/user"
 import { Message } from "./entities/message"
 
@@ -20,6 +25,7 @@ export enum MessageActionType {
 export type TextMessageContent = {
   type: MessageType.TEXT
   text: string
+  files?: { name: string; id: string; url: string; type?: string }[]
 }
 
 export type EventContent = {
@@ -71,6 +77,7 @@ export type SendTextOptionParams = Omit<PublishParameters, "message" | "channel"
   mentionedUsers?: MessageMentionedUsers
   textLinks?: TextLink[]
   quotedMessage?: Message
+  files?: FileList | File[] | SendFileParameters["file"][]
 }
 
 export type EnhancedMessageEvent = PubNub.MessageEvent & {


### PR DESCRIPTION
Basic file upload implementation, it consists of:
- `files` parameter in `channel.sendText()` method, allowing clients to attach 0, 1, or multiple files to each message
- `files` getter in every Message object, which is an array of id, name, url and type of each file
- `files` field in MessageDraft object that can be freely set and modified, files will be attached once a message is sent
- `getFiles()` and `deleteFile()` methods that can be used to access a full list of files sent on a channel (name, id and url) and delete a file from the channel (unfortunately this will not modify the messages that have the file attached, technical limitations)
- `message.delete()` function will automatically delete files attached to the message; there's a new `preserveFiles` option that can be used to disable this behavior

Technical considerations:
- one of the requirements specified that it should be possible to attach multiple files to each message, and PubNub APIs do not allow this; there's a workaround in this implementation, basically files are sent independently and without storing them in messages history, and the final message has a content field with an array of files data
- file encryption with cypher keys was not implemented/tested -> files in chat are generally meant to be public, and this would take a lot of extra time 