### PR TITLE
feat(lib): message reporting changes

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,11 +1,16 @@
 ---
 name: pubnub-js-chat
-version: v0.7.3
+version: v0.8.0
 scm: github.com/pubnub/js-chat
 schema: 1
 files:
   - lib/dist/index.js
 changelog:
+  - date: 2024-07-31
+    version: v0.8.0
+    changes:
+      - type: feature
+        text: "Message report events are now sent to a moderation sub-channel. Methods for user reporting and message reporting to a global admin channel are now deprecated and renamed with a DEPRECATED_ prefix."
   - date: 2024-06-18
     version: v0.7.3
     changes:

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/chat",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "PubNub JavaScript Chat SDK",
   "author": "PubNub <support@pubnub.com>",
   "license": "SEE LICENSE IN LICENSE",

--- a/lib/src/entities/channel.ts
+++ b/lib/src/entities/channel.ts
@@ -750,12 +750,12 @@ export class Channel {
   }
 
   /**
-   * Flagged messages
+   * Reported messages
    */
 
-  async getFlaggedMessagesHistory(
+  async getMessageReportsHistory(
     params: { startTimetoken?: string; endTimetoken?: string; count?: number } = {}
-  ) {
+  ): Promise<{ events: Event<"report">[]; isMore: boolean }> {
     const channel = `${INTERNAL_MODERATION_PREFIX}${this.id}`
     return this.chat.getEventsHistory({
       ...params,
@@ -763,7 +763,7 @@ export class Channel {
     })
   }
 
-  listenForFlaggedMessages(callback: (event: Event<"report">) => void) {
+  streamMessageReports(callback: (event: Event<"report">) => void) {
     const channel = `${INTERNAL_MODERATION_PREFIX}${this.id}`
     return this.chat.listenForEvents({
       channel,

--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -368,7 +368,8 @@ export class Message {
     await this.chat.pinMessageToChannel(this, channel!)
   }
 
-  async report(reason: string) {
+  /** @deprecated */
+  async DEPRECATED_report(reason: string) {
     const channel = INTERNAL_ADMIN_CHANNEL
     const payload = {
       text: this.text,
@@ -380,7 +381,7 @@ export class Message {
     return await this.chat.emitEvent({ channel, type: "report", payload })
   }
 
-  async reportOnChannel(reason: string) {
+  async report(reason: string) {
     const channel = `${INTERNAL_MODERATION_PREFIX}${this.channelId}`
     const payload = {
       text: this.text,

--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -369,6 +369,18 @@ export class Message {
   }
 
   async report(reason: string) {
+    const channel = INTERNAL_ADMIN_CHANNEL
+    const payload = {
+      text: this.text,
+      reason,
+      reportedMessageChannelId: this.channelId,
+      reportedMessageTimetoken: this.timetoken,
+      reportedUserId: this.userId,
+    }
+    return await this.chat.emitEvent({ channel, type: "report", payload })
+  }
+
+  async reportOnChannel(reason: string) {
     const channel = `${INTERNAL_MODERATION_PREFIX}${this.channelId}`
     const payload = {
       text: this.text,

--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -7,7 +7,7 @@ import {
   TextMessageContent,
   MessageActionType,
 } from "../types"
-import { INTERNAL_ADMIN_CHANNEL } from "../constants"
+import { INTERNAL_ADMIN_CHANNEL, INTERNAL_MODERATION_PREFIX } from "../constants"
 import { getErrorProxiedEntity } from "../error-logging"
 import { MessageElementsUtils } from "../message-elements-utils"
 import { defaultGetMessageResponseBody } from "../default-values"
@@ -369,7 +369,7 @@ export class Message {
   }
 
   async report(reason: string) {
-    const channel = INTERNAL_ADMIN_CHANNEL
+    const channel = `${INTERNAL_MODERATION_PREFIX}${this.channelId}`
     const payload = {
       text: this.text,
       reason,

--- a/lib/src/entities/user.ts
+++ b/lib/src/entities/user.ts
@@ -218,7 +218,8 @@ export class User {
   /*
    * Other
    */
-  async report(reason: string) {
+  /** @deprecated */
+  async DEPRECATED_report(reason: string) {
     const channel = INTERNAL_ADMIN_CHANNEL
     const payload = {
       reason,

--- a/lib/tests/message.test.ts
+++ b/lib/tests/message.test.ts
@@ -1,6 +1,7 @@
 import {
   Channel,
   Chat,
+  INTERNAL_ADMIN_CHANNEL,
   Message,
   MessageDraft,
   CryptoUtils,
@@ -473,7 +474,10 @@ describe("Send message test", () => {
     await reportedMessage.report(reportReason)
     await sleep(150) // history calls have around 130ms of cache time
 
-    const adminChannelHistory = await channel.getFlaggedMessages({ count: 1 })
+    const adminChannel = await chat.getChannel(INTERNAL_ADMIN_CHANNEL)
+    expect(adminChannel).toBeDefined()
+
+    const adminChannelHistory = await adminChannel.getHistory({ count: 1 })
     const reportMessage = adminChannelHistory.messages[0]
 
     expect(reportMessage?.content.type).toBe("report")

--- a/lib/tests/message.test.ts
+++ b/lib/tests/message.test.ts
@@ -474,6 +474,28 @@ describe("Send message test", () => {
     await reportedMessage.report(reportReason)
     await sleep(150) // history calls have around 130ms of cache time
 
+    const { events } = await channel.getMessageReportsHistory()
+    const reportMessage = events[0]
+
+    expect(reportMessage?.type).toBe("report")
+    expect(reportMessage?.payload.reason).toBe(reportReason)
+    expect(reportMessage?.payload.reportedMessageChannelId).toBe(reportedMessage.channelId)
+    expect(reportMessage?.payload.reportedMessageTimetoken).toBe(reportedMessage.timetoken)
+    expect(reportMessage?.payload.reportedUserId).toBe(reportedMessage.userId)
+  })
+
+  test("should report a message (deprecated)", async () => {
+    const messageText = "Test message to be reported"
+    const reportReason = "Inappropriate content"
+
+    await channel.sendText(messageText)
+    await sleep(150) // history calls have around 130ms of cache time
+
+    const history = await channel.getHistory({ count: 1 })
+    const reportedMessage = history.messages[0]
+    await reportedMessage.DEPRECATED_report(reportReason)
+    await sleep(150) // history calls have around 130ms of cache time
+
     const adminChannel = await chat.getChannel(INTERNAL_ADMIN_CHANNEL)
     expect(adminChannel).toBeDefined()
 

--- a/lib/tests/message.test.ts
+++ b/lib/tests/message.test.ts
@@ -1,7 +1,6 @@
 import {
   Channel,
   Chat,
-  INTERNAL_ADMIN_CHANNEL,
   Message,
   MessageDraft,
   CryptoUtils,
@@ -474,10 +473,7 @@ describe("Send message test", () => {
     await reportedMessage.report(reportReason)
     await sleep(150) // history calls have around 130ms of cache time
 
-    const adminChannel = await chat.getChannel(INTERNAL_ADMIN_CHANNEL)
-    expect(adminChannel).toBeDefined()
-
-    const adminChannelHistory = await adminChannel.getHistory({ count: 1 })
+    const adminChannelHistory = await channel.getFlaggedMessages({ count: 1 })
     const reportMessage = adminChannelHistory.messages[0]
 
     expect(reportMessage?.content.type).toBe("report")

--- a/lib/tests/user.test.ts
+++ b/lib/tests/user.test.ts
@@ -121,7 +121,7 @@ describe("User test", () => {
 
   test("should report a user", async () => {
     const reportReason = "Inappropriate behavior"
-    await user.report(reportReason)
+    await user.DEPRECATED_report(reportReason)
     await sleep(150) // history calls have around 130ms of cache time
 
     const adminChannel =


### PR DESCRIPTION
feat: Message report events are now sent to a moderation sub-channel. Methods for user reporting and message reporting to a global admin channel are now deprecated and renamed with a DEPRECATED_ prefix