### PR TITLE
feat: add statusField: true for getMembers()

### DIFF
--- a/lib/src/entities/channel.ts
+++ b/lib/src/entities/channel.ts
@@ -465,6 +465,7 @@ export class Channel {
       channel: this.id,
       include: {
         totalCount: true,
+        statusField: true,
         customFields: true,
         UUIDFields: true,
         customUUIDFields: true,


### PR DESCRIPTION
Adds `statusField: true` to `getMembers()`, as it does not make sense that customFields would be returned but a statusField would not.

Solves https://github.com/pubnub/js-chat/issues/186