### PR TITLE
Fix: Remove Keys that are Empty

### DIFF
--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -127,9 +127,18 @@ export class Message {
     const newActions = this.actions || {}
     newActions[type] ||= {}
     newActions[type][value] ||= []
-    newActions[type][value] = newActions[type][value].filter(
+    const tempActionValue = newActions[type][value].filter(
       (r) => r.actionTimetoken !== actionTimetoken || r.uuid !== uuid
     )
+
+    // Don't have an object with a key that is empty specifically for reactions like emojis
+    if(tempActionValue.length === 0) {
+      delete newActions[type][value]
+    }
+    else {
+      newActions[type][value] = tempActionValue
+    }
+
     return newActions
   }
 
@@ -193,7 +202,7 @@ export class Message {
   }
 
   /**
-    @deprecated use getMessageElements instead
+   @deprecated use getMessageElements instead
    */
   getLinkedText() {
     return this.getMessageElements()

--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -132,10 +132,9 @@ export class Message {
     )
 
     // Don't have an object with a key that is empty specifically for reactions like emojis
-    if(tempActionValue.length === 0) {
+    if (tempActionValue.length === 0) {
       delete newActions[type][value]
-    }
-    else {
+    } else {
       newActions[type][value] = tempActionValue
     }
 
@@ -202,7 +201,7 @@ export class Message {
   }
 
   /**
-   @deprecated use getMessageElements instead
+    @deprecated use getMessageElements instead
    */
   getLinkedText() {
     return this.getMessageElements()

--- a/lib/src/entities/message.ts
+++ b/lib/src/entities/message.ts
@@ -127,15 +127,15 @@ export class Message {
     const newActions = this.actions || {}
     newActions[type] ||= {}
     newActions[type][value] ||= []
-    const tempActionValue = newActions[type][value].filter(
+    const updatedActions = newActions[type][value].filter(
       (r) => r.actionTimetoken !== actionTimetoken || r.uuid !== uuid
     )
 
     // Don't have an object with a key that is empty specifically for reactions like emojis
-    if (tempActionValue.length === 0) {
+    if (updatedActions.length === 0) {
       delete newActions[type][value]
     } else {
-      newActions[type][value] = tempActionValue
+      newActions[type][value] = updatedActions
     }
 
     return newActions


### PR DESCRIPTION
Remove reaction keys that are empty so we don't get values like the following

```ts
{
 "❤️":  []
}

```


Updated code will produce
```
{
}
```